### PR TITLE
fix for reverting a change back to original promise

### DIFF
--- a/addon/components/power-select.ts
+++ b/addon/components/power-select.ts
@@ -375,6 +375,11 @@ export default class PowerSelect extends Component<PowerSelectArgs> {
         }
       });
     } else {
+      if (this._lastSelectedPromise) {
+        // no longer using a promise
+        removeObserver(this._lastSelectedPromise, 'content', this, this._selectedObserverCallback);
+        this._lastSelectedPromise = undefined;
+      }
       this._resolvedSelected = undefined;
       // Don't highlight args.selected array on multi-select
       if (!Array.isArray(this.args.selected)) {


### PR DESCRIPTION
When @selected is a promise initially, you update it to a non-promise value, and then revert the change back to the original promise value, EPS was ignoring the change as it still held a reference to _lastSelectedPromise.
Should fix #1467